### PR TITLE
mac os build + utf-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 <img  align="MIDDLE" width="400" height="200" src="https://d18l82el6cdm1i.cloudfront.net/uploads/dfugTjn2WC-tm_palindrome.gif"/>
 </div>
 
-## Trabalho IFMG 2018 - Teoria da Computação
+## Trabalho IFMG 2018 - Teoria da ComputaÃ§Ã£o
 
-### Implementação de um simulador de uma maquina de Turing (MT) em linguagem C.
+### ImplementaÃ§Ã£o de um simulador de uma maquina de Turing (MT) em linguagem C.
 
 Simulador na qual deve ser passada uma maquina de Turing descrita na linguagem pre-definida 
-e posteriormente em execução fornecer uma entrada, no qual o simulador irá executar a fita
-seguindo a maquina descrita em arquivo passada por parâmetro.
+e posteriormente em execuÃ§Ã£o fornecer uma entrada, no qual o simulador irÃ¡ executar a fita
+seguindo a maquina descrita em arquivo passada por parÃ¢metro.
 
-Implementação seguindo especificações do trabalho da disciplina Teoria da Computação 5º período IFMG campus Formiga 2018.
+ImplementaÃ§Ã£o seguindo especificaÃ§Ãµes do trabalho da disciplina Teoria da ComputaÃ§Ã£o 5Âº perÃ­odo IFMG campus Formiga 2018.
 Professor: Walace de Almeida Rodrigues.
 
-Autor: Júlio César de Melo Cândido.
+Autor: JÃºlio CÃ©sar de Melo CÃ¢ndido.
 
 Enunciado: https://drive.google.com/open?id=1Yy40eHoCz7ycxLzKEO7QvzMQwuJxuSTY

--- a/cadeia.mt
+++ b/cadeia.mt
@@ -1,5 +1,5 @@
 ;
-; Express„o definida por a^(N)b^(2N)c^(3N)
+; Express√£o definida por a^(N)b^(2N)c^(3N)
 ;
 bloco main 0
 	0 _ -- * i 11

--- a/decodArgs.c
+++ b/decodArgs.c
@@ -2,17 +2,17 @@
 
 void decodArgs(int argc, char *argv[])
 {
-    modo = type_r; // Modo setado em modo padrão .
-    n_step = 1;    // Numero padrão parâmetro -s.
-    step_arg = 1;  // Numero padrão parâmetro -s.
+    modo = type_r; // Modo setado em modo padrÃ£o .
+    n_step = 1;    // Numero padrÃ£o parÃ¢metro -s.
+    step_arg = 1;  // Numero padrÃ£o parÃ¢metro -s.
 
-    strncpy(delim_cabecote, DELIM_PADRAO, 2); // Setando os delimitadores do cabeçote padrão "( )".
+    strncpy(delim_cabecote, DELIM_PADRAO, 2); // Setando os delimitadores do cabeÃ§ote padrÃ£o "( )".
 
     if (argc == 2)
         return;
 
     for (size_t i = 1; i < argc; i++)
-        // Pega os PARÂMETROS.
+        // Pega os PARÃ‚METROS.
         if (argv[i][0] == '-')
         {
             if (strcmp(argv[i], "-r") == 0)
@@ -25,12 +25,12 @@ void decodArgs(int argc, char *argv[])
                 modo = type_s; // Tipo -s
                 if (argc >= (i + 1))
                 {
-                    // Pegando e tratando parâmetro -s
+                    // Pegando e tratando parÃ¢metro -s
                     n_step = atol(argv[i + 1]) + 1;
                     step_arg = n_step;
                     if (n_step == 0)
                     {
-                        fprintf(stderr, "\nERROR PARÂMETRO '-S' VALOR \"N\" NÃO INFORMADO OU IGUAL A ZERO\n\n");
+                        fprintf(stderr, "\nERROR PARÃ‚METRO '-S' VALOR \"N\" NÃƒO INFORMADO OU IGUAL A ZERO\n\n");
                         exit(EXIT_FAILURE);
                     }
                 }
@@ -43,8 +43,8 @@ void decodArgs(int argc, char *argv[])
             }
             else
             {
-                // Parâmetro invalido.
-                fprintf(stderr, "\nERROR SINTAXE PARÂMETRO %s INVALIDO\n\n", argv[i]);
+                // ParÃ¢metro invalido.
+                fprintf(stderr, "\nERROR SINTAXE PARÃ‚METRO %s INVALIDO\n\n", argv[i]);
                 exit(EXIT_FAILURE);
             }
         }

--- a/decodArgs.h
+++ b/decodArgs.h
@@ -7,7 +7,7 @@
 
 #define DELIM_PADRAO "()\0"
 /*
-    Enum para definir qual PAR?METRO de impress„o a MT executara.
+    Enum para definir qual PAR√ÇMETRO de impress√£o a MT executara.
 */
 
 typedef enum
@@ -17,13 +17,13 @@ typedef enum
     type_s  //  Tipo n step para e pega novo modo
 } type_mod;
 
-type_mod modo; // Vari·vel GLOBAL de controle de PAR¬METRO
+type_mod modo; // Vari√°vel GLOBAL de controle de PAR√ÇMETRO
 
-size_t n_step;          // vari·vel de controle para entrada do tipo -S (numero de passos)
-size_t step_arg;        // vari·vel de controle para novas entradas do tipo -s
-char delim_cabecote[3]; // Delimitador do cabeÁote entrada -h
+size_t n_step;          // vari√°vel de controle para entrada do tipo -S (numero de passos)
+size_t step_arg;        // vari√°vel de controle para novas entradas do tipo -s
+char delim_cabecote[3]; // Delimitador do cabe√ßote entrada -h
 
-// LÍ os par‚metros e decodifica.
+// L√™ os par√¢metros e decodifica.
 
 void decodArgs(int argc, char *argv[]);
 

--- a/decodc.c
+++ b/decodc.c
@@ -2,29 +2,29 @@
 
 void getBlocos(FILE *arq)
 {
-  char **vetline;         // Saida da funÁ„o decodline.
+  char **vetline;         // Saida da fun√ß√£o decodline.
   char line[TAM_LINE];    // Vetor de char, pra leitura do arquivo.
   short int flag_fim = 0; // Fim da MT.
   n_blocos = 0;           // Tamanho do vetor blocos.
   rewind(arq);            // Reinicia ponteiro do arquivo.
-  // Faz leitura no aquivo, ate "\n ou \0", ou tamanho passado par‚metro.
+  // Faz leitura no aquivo, ate "\n ou \0", ou tamanho passado par√¢metro.
   fgets(line, TAM_LINE - 1, arq);
   while (!feof(arq))
   {
-    // Trata coment·rio com, com ";" no incio da linha.
+    // Trata coment√°rio com, com ";" no incio da linha.
     if (line[0] == ';')
     {
       fgets(line, TAM_LINE - 1, arq);
       continue;
     }
-    // Chamada da funÁ„o quebrando a linha em tokens.
+    // Chamada da fun√ß√£o quebrando a linha em tokens.
     vetline = decodline(line);
     if (!vetline)
     {
       fgets(line, TAM_LINE - 1, arq);
       continue;
     }
-    // Verifica se a linha È uma declaraÁ„o de um bloco.
+    // Verifica se a linha √© uma declara√ß√£o de um bloco.
     if ((strcmp(vetline[0], "bloco") == 0) && flag_fim)
     {
       fprintf(stderr, "\nERROR SINTAXE BLOCOS, BLOCO '%s'\n\n", blocos[n_blocos - 1].name);
@@ -57,7 +57,7 @@ void getBlocos(FILE *arq)
         blocos = (bloco *)realloc(blocos, sizeof(bloco) * (++n_blocos));
       // Setando o bloco no vetor blocos.
       strcpy(blocos[n_blocos - 1].name, vetline[1]);
-      blocos[n_blocos - 1].position_file = ftell(arq); // posiÁ„o no arquivo.
+      blocos[n_blocos - 1].position_file = ftell(arq); // posi√ß√£o no arquivo.
       strcpy(blocos[n_blocos - 1].initState, vetline[2]);
     }
     if (strcmp(vetline[0], "fim") == 0)
@@ -75,16 +75,16 @@ void getBlocos(FILE *arq)
 
 char **decodline(char *line)
 {
-  char **vetoken = NULL; // Vetor de string de saÌda.
+  char **vetoken = NULL; // Vetor de string de sa√≠da.
   char *token = NULL;    // String usada para strtok.
   cont = 0;              // Tamanho do Vetor de string (vetoken).
 
-  token = strtok(line, ";\n");  // Trata coment·rio no meio da linha.
-  token = strtok(token, " \t"); // Quebra em tabulaÁ„o e/ou espaÁo dos tokens.
+  token = strtok(line, ";\n");  // Trata coment√°rio no meio da linha.
+  token = strtok(token, " \t"); // Quebra em tabula√ß√£o e/ou espa√ßo dos tokens.
 
   while (token)
   {
-    // Aloca e expande o tamanho do vetor para saÌda.
+    // Aloca e expande o tamanho do vetor para sa√≠da.
     if (!vetoken)
       vetoken = (char **)malloc((++cont) * sizeof(char *));
     else

--- a/decodc.h
+++ b/decodc.h
@@ -18,23 +18,23 @@ typedef struct
 {
   char name[TAM_BLOCK];      // Nome do bloco declarado.
   char initState[TAM_STATE]; // Estado inicial do bloco.
-  size_t position_file;      // posição do bloco no arquivo.
+  size_t position_file;      // posiÃ§Ã£o do bloco no arquivo.
 } bloco;
 
 /*
   blocos:   Nome dado ao vetor com todos os blocos encontrados no arquivo.
   n_blocos: Indicador do tamanho do vetor blocos, com struct bloco.
-  cont:     Indicador do tamanho do vetor de saída da função decodline.
+  cont:     Indicador do tamanho do vetor de saÃ­da da funÃ§Ã£o decodline.
 */
 
 bloco *blocos;
 size_t n_blocos;
 size_t cont;
 
-/* Função getBlocos: pega todos os blocos no arquivo, salvando em uma lista
-      com nome, posição no arquivo e estado inicial do bloco de instrução.
+/* FunÃ§Ã£o getBlocos: pega todos os blocos no arquivo, salvando em uma lista
+      com nome, posiÃ§Ã£o no arquivo e estado inicial do bloco de instruÃ§Ã£o.
 
-   Função decodline: pega uma linha como entrada e quebra em
+   FunÃ§Ã£o decodline: pega uma linha como entrada e quebra em
           tokens e retorna um vetor de strings com os tonkes.
 */
 

--- a/exec.c
+++ b/exec.c
@@ -3,16 +3,16 @@
 static size_t n_exec = 0;
 
 /*
-  FunÁ„o onde procura pelo nome do bloco, e seta as vari·veis de controle da
-    MT, de acordo com as vari·veis do bloco a ser executado.
-        vari·veis de um bloco:
+  Fun√ß√£o onde procura pelo nome do bloco, e seta as vari√°veis de controle da
+    MT, de acordo com as vari√°veis do bloco a ser executado.
+        vari√°veis de um bloco:
                 name          : Nome do bloco.
                 initState     : Numero do estado inicial do bloco.
-                position_file : PosiÁ„o no arquivo onde inicia o bloco.
-                ================> vari·veis de controle da MT <==============
+                position_file : Posi√ß√£o no arquivo onde inicia o bloco.
+                ================> vari√°veis de controle da MT <==============
                 name_bloco    : Nome do bloco a ser executado.
                 estado_atual  : Estado atual na MT.
-                seek          : PosiÁ„o do arquivo para busca de blocos.
+                seek          : Posi√ß√£o do arquivo para busca de blocos.
                 n_bloco       : Numero de blocos salvos no vetor (length).
 */
 void setseekbloco(FILE *arq, char *name_bloco)
@@ -25,37 +25,37 @@ void setseekbloco(FILE *arq, char *name_bloco)
             seek = blocos[i].position_file;
             return;
         }
-    fprintf(stderr, "\nERRO BLOCO '%s' N√O ENCONTRADO\n", name_bloco);
+    fprintf(stderr, "\nERRO BLOCO '%s' N√ÉO ENCONTRADO\n", name_bloco);
     para(arq);
 }
 
 void exec(FILE *arq)
 {
-    n_exec = 0;                                           // Contador de n˙meros de execuÁ„o.
+    n_exec = 0;                                           // Contador de n√∫meros de execu√ß√£o.
     pilha_blocos = initStack();                           // Pilha para chamadas de blocos.
-    cabecote = 0;                                         // Reset posiÁ„o do cabeÁote sobre a fita.
-    char **vetoken = NULL;                                // Vetor com as tokens das linhas de instruÁ„o.
+    cabecote = 0;                                         // Reset posi√ß√£o do cabe√ßote sobre a fita.
+    char **vetoken = NULL;                                // Vetor com as tokens das linhas de instru√ß√£o.
     char *line = (char *)malloc(sizeof(char) * TAM_LINE); // "String" leitura do aquivo.
-    char type_cod;                                        // Tipo de instruÁ„o a ser executada, 0 = instruÁ„o normal, 1 = instruÁ„o chamada bloco.
+    char type_cod;                                        // Tipo de instru√ß√£o a ser executada, 0 = instru√ß√£o normal, 1 = instru√ß√£o chamada bloco.
 
-    setseekbloco(arq, "main");  // Seta vari·veis de controle do bloco main.
-    fseek(arq, seek, SEEK_SET); //  Aplica posiÁ„o inicio do bloco main.
+    setseekbloco(arq, "main");  // Seta vari√°veis de controle do bloco main.
+    fseek(arq, seek, SEEK_SET); //  Aplica posi√ß√£o inicio do bloco main.
 
     fgets(line, TAM_LINE - 1, arq); // Leitura de uma linha do arq.
     while (!feof(arq))
     {
         if (NO_LOOP)
-            if (n_exec >= LIMIT_LOOP) // Verifica quant de interaÁıes, tratar loops.
+            if (n_exec >= LIMIT_LOOP) // Verifica quant de intera√ß√µes, tratar loops.
             {
                 if (modo != type_s)
                 {
-                    print(0, arq); // Chama funÁ„o para imprimir
+                    print(0, arq); // Chama fun√ß√£o para imprimir
                     modo = type_v; // Seta para imprimir.
-                }                  // Verifica se esta no modo de n„o impress„o.
+                }                  // Verifica se esta no modo de n√£o impress√£o.
                 fprintf(stderr, "\nMT PARADA, POSSIVEL LOOP INFINITO\n\n");
                 para(arq);
             }
-        if (line[0] == ';') // Verifica linha de coment·rio.
+        if (line[0] == ';') // Verifica linha de coment√°rio.
         {
             fgets(line, TAM_LINE - 1, arq);
             continue;
@@ -63,25 +63,25 @@ void exec(FILE *arq)
 
         vetoken = decodline(line); // Decodifica linha e retorna tokens
 
-        if (!vetoken) // Verifica se a linha foi de coment·rio.
+        if (!vetoken) // Verifica se a linha foi de coment√°rio.
         {
             fgets(line, TAM_LINE - 1, arq);
             continue;
         }
 
-        if (strcmp(vetoken[0], "fim") == 0) // Verifica se n„o existe transiÁ„o definida.
+        if (strcmp(vetoken[0], "fim") == 0) // Verifica se n√£o existe transi√ß√£o definida.
         {
-            strtok(estado_atual, "\n"); //  Remove \n para apresentaÁ„o no printf.
-            modo = type_v;              //   Muda modo para que acha sempre essa impress„o.
-            print(0, arq);              //    Printa essa ultima execuÁ„o.
-            // ----- MANDA MSG COM ERRO PARA O USU¡RIO ----- //
-            fprintf(stderr, "\nERROR TRANSI«√O BLOCO '%s' ESTADO '%s' COM '%c' N√O DEFINIDA\n\n", bloco_atual, estado_atual, fita[cabecote]);
-            fprintf(stderr, "ESTADO '%s' N√O EXISTE ", estado_atual);
-            fprintf(stderr, "OU SIMBOLO '%C' N√O DEFINIDO NO ALFABETO\n", fita[cabecote]);
+            strtok(estado_atual, "\n"); //  Remove \n para apresenta√ß√£o no printf.
+            modo = type_v;              //   Muda modo para que acha sempre essa impress√£o.
+            print(0, arq);              //    Printa essa ultima execu√ß√£o.
+            // ----- MANDA MSG COM ERRO PARA O USU√ÅRIO ----- //
+            fprintf(stderr, "\nERROR TRANSI√á√ÉO BLOCO '%s' ESTADO '%s' COM '%c' N√ÉO DEFINIDA\n\n", bloco_atual, estado_atual, fita[cabecote]);
+            fprintf(stderr, "ESTADO '%s' N√ÉO EXISTE ", estado_atual);
+            fprintf(stderr, "OU SIMBOLO '%C' N√ÉO DEFINIDO NO ALFABETO\n", fita[cabecote]);
             para(arq); // Finaliza MT.
         }
 
-        if (atoi(vetoken[0]) == atoi(estado_atual)) // Verifica se esta numa transiÁ„o desse estado.
+        if (atoi(vetoken[0]) == atoi(estado_atual)) // Verifica se esta numa transi√ß√£o desse estado.
         {
             if (cont < 3) // Verifica erro de SINTAXE.
             {
@@ -90,22 +90,22 @@ void exec(FILE *arq)
                 fclose(arq);
                 exit(EXIT_FAILURE);
             }
-            if (strcmp(vetoken[2], "--") == 0) // Define o tipo da instruÁ„o.
-                type_cod = 0;                  // InstruÁ„o normal.
+            if (strcmp(vetoken[2], "--") == 0) // Define o tipo da instru√ß√£o.
+                type_cod = 0;                  // Instru√ß√£o normal.
             else
-                type_cod = 1; // InstruÁ„o
+                type_cod = 1; // Instru√ß√£o
 
             simbolo_atual[0] = fita[cabecote]; // Seta simbolo atual da fita.
             simbolo_atual[1] = '\0';
             if ((type_cod == 0) && ((strcmp(simbolo_atual, vetoken[1]) == 0) ||
                                     (strcmp(vetoken[1], "*") == 0)))
-            { // Verifica se pertence a esta transiÁ„o.
+            { // Verifica se pertence a esta transi√ß√£o.
 
-                n_exec++;                // Incrementa num de execuÁ„o feitas.
-                execinstr(vetoken, arq); // Executa linha de instruÁıes normais.
+                n_exec++;                // Incrementa num de execu√ß√£o feitas.
+                execinstr(vetoken, arq); // Executa linha de instru√ß√µes normais.
             }
             else if (type_cod == 1)
-                execblock(vetoken, arq); // Executa linha de instruÁıes de blocos.
+                execblock(vetoken, arq); // Executa linha de instru√ß√µes de blocos.
         }
 
         if (vetoken) // Desaloca Tokens.
@@ -117,24 +117,24 @@ void exec(FILE *arq)
     }
 }
 /*
-    Para execuÁ„o da MT.
+    Para execu√ß√£o da MT.
 */
 void para(FILE *arq)
 {
-    printf("\nMT ENCERROU:  %ld execuÁıes efetuadas\n\n", n_exec);
+    printf("\nMT ENCERROU:  %ld execu√ß√µes efetuadas\n\n", n_exec);
     fclose(arq);
     exit(EXIT_SUCCESS);
 }
 /*
-      Executa transiÁ„o 'setando' as vari·veis de controle
+      Executa transi√ß√£o 'setando' as vari√°veis de controle
         da MT, printa se estiver no modo correto, e volta para
-        inicio do bloco no aquivo para busca de nova transiÁ„o
+        inicio do bloco no aquivo para busca de nova transi√ß√£o
         com novo estado e simbolo.
 */
 void execinstr(char **vetline, FILE *arq)
 {
 
-    char fin = 0; // Define se Fim de execuÁ„o; 1==fim.
+    char fin = 0; // Define se Fim de execu√ß√£o; 1==fim.
     // Verifica erro de SINTAXE.
     if (cont < 6)
     {
@@ -148,10 +148,10 @@ void execinstr(char **vetline, FILE *arq)
         fita[cabecote] = vetline[3][0];
 
     
-    // movimento cabeÁote
+    // movimento cabe√ßote
     if (strcmp(vetline[4], "e") == 0)
     {
-        // Tratamento se o cabecote ir alÈm do inicio da fila, Ìndice -1 em C.
+        // Tratamento se o cabecote ir al√©m do inicio da fila, √≠ndice -1 em C.
         if (cabecote == 0)
         {
             for (int i = (strlen(fita) - 2); i >= 0; i--)
@@ -177,7 +177,7 @@ void execinstr(char **vetline, FILE *arq)
     }
     
     // Estado novo
-    if (strcmp(vetline[5], "pare") == 0) // Verifica Fim do algorÌtimo.
+    if (strcmp(vetline[5], "pare") == 0) // Verifica Fim do algor√≠timo.
         fin = 1;
     else if (strcmp(vetline[5], "retorne") == 0) // Verifica retorno de um bloco.
     {
@@ -189,16 +189,16 @@ void execinstr(char **vetline, FILE *arq)
                 printf("\nERRO DE RETORNO DO BLOCO '%s' \n", bloco_atual);
                 para(arq);
             }
-            /* Seta vari·veis de controle:
+            /* Seta vari√°veis de controle:
                 bloco_atual : Nome do bloco atual.
-                n_bloco_atual : PosiÁ„o no vetor (Ìndice).
+                n_bloco_atual : Posi√ß√£o no vetor (√≠ndice).
                 novo_estado   : Novo Estado da MT, estado de retorno.
                 estado_atual  : Estado atual da MT.
             */
             strcpy(bloco_atual, (char *)retorno->recall_bloco);
             strcpy(novo_estado, retorno->recall_state);
             strcpy(estado_atual, novo_estado);
-            // Verifica se a retornada È um pare.
+            // Verifica se a retornada √© um pare.
             if (strcmp(novo_estado, "pare") == 0)
             {
                 fin = 1;
@@ -209,7 +209,7 @@ void execinstr(char **vetline, FILE *arq)
     }
     else
     {
-        // Caso n„o seja um retorno seta o novo estado.
+        // Caso n√£o seja um retorno seta o novo estado.
         if (strcmp(vetline[5], "*") == 0)
             strcpy(novo_estado, estado_atual);
         else
@@ -220,8 +220,8 @@ void execinstr(char **vetline, FILE *arq)
         if (strcmp("!", vetline[6]) == 0)
             modo = type_v;
     /*
-      Imprime a execuÁ„o e seta o inicio do bloco no arq para
-          nova busca de transiÁ„o para novo estado e simbolo.
+      Imprime a execu√ß√£o e seta o inicio do bloco no arq para
+          nova busca de transi√ß√£o para novo estado e simbolo.
     */
     print(fin, arq);
     setseekbloco(arq, bloco_atual);
@@ -229,16 +229,16 @@ void execinstr(char **vetline, FILE *arq)
     fseek(arq, seek, SEEK_SET);
 }
 /*
-    Executa instruÁ„o de chamada de blocos, empilha o bloco atual.
+    Executa instru√ß√£o de chamada de blocos, empilha o bloco atual.
 */
 void execblock(char **vetline, FILE *arq)
 {
-    print(0, arq); // Imprime execuÁ„o atual.
+    print(0, arq); // Imprime execu√ß√£o atual.
     recall *retorno = NULL;
     retorno = (recall *)malloc(sizeof(recall)); // Aloca ED de chamada de bloco.
-    if (!retorno)                               // Trata possÌvel erro de alocaÁ„o.
+    if (!retorno)                               // Trata poss√≠vel erro de aloca√ß√£o.
     {
-        fprintf(stderr, "\nERRO ALOCA«√O DE CHAMADA DE BLOCO\n\n");
+        fprintf(stderr, "\nERRO ALOCA√á√ÉO DE CHAMADA DE BLOCO\n\n");
         exit(EXIT_FAILURE);
     }
 
@@ -248,9 +248,9 @@ void execblock(char **vetline, FILE *arq)
 
     strcpy(retorno->recall_state, vetline[2]); //    Seta na strtc estado de retorno.
     pushStack(pilha_blocos, retorno);          //    Empilha esse bloco na ED pilha.
-    setseekbloco(arq, vetline[1]);             //    Seta vari·veis de controle.
-    print(0, arq);                             //    Imprime execuÁ„o.
-    fseek(arq, seek, SEEK_SET);                //    Seta posiÁ„o no arq com novo bloco.
+    setseekbloco(arq, vetline[1]);             //    Seta vari√°veis de controle.
+    print(0, arq);                             //    Imprime execu√ß√£o.
+    fseek(arq, seek, SEEK_SET);                //    Seta posi√ß√£o no arq com novo bloco.
 
     if (cont > 3) // Trata operador "!"
         if (strcmp("!", vetline[3]) == 0)
@@ -269,11 +269,11 @@ void print(int fin, FILE *arq)
     char fitaprint[LEN_FITA_PRINT + 6];
     char ponts[TAM_BLOCK];
 
-    if (modo != type_r) // Modo de impress„o.
+    if (modo != type_r) // Modo de impress√£o.
     {
         dots = TAM_BLOCK - strlen(bloco_atual) - 1;                      // Sobra do nome do bloco, a ser preenchido de pontos.
-        fitapos = cabecote + (int)((LEN_FITA_PRINT) / 2) - strlen(fita); // Excesso ou falta de sÌmbolos depois do cabeÁote.
-        fitantes = (int)((LEN_FITA_PRINT) / 2) - cabecote;               // Excesso ou falta de sÌmbolos antes do cabeÁote.
+        fitapos = cabecote + (int)((LEN_FITA_PRINT) / 2) - strlen(fita); // Excesso ou falta de s√≠mbolos depois do cabe√ßote.
+        fitantes = (int)((LEN_FITA_PRINT) / 2) - cabecote;               // Excesso ou falta de s√≠mbolos antes do cabe√ßote.
         // Verifica se houve excesso antes.
         if (fitantes < 0)
         {
@@ -284,7 +284,7 @@ void print(int fin, FILE *arq)
         if (fitapos < 0)
             fitapos *= -1;
         int cont = 0;
-        // Cria a "LINHA" de impress„o.
+        // Cria a "LINHA" de impress√£o.
         if (flagvaziantes) // Trata se tiver menos de 20 antes do cabecote.
         {
             strcpy(fitaprint, "");
@@ -303,7 +303,7 @@ void print(int fin, FILE *arq)
         }
 
         char pont[6];
-        // Cria "visual" do cabeÁote.
+        // Cria "visual" do cabe√ßote.
         pont[0] = (char)delim_cabecote[0];
         pont[1] = ' ';
         pont[2] = (char)fita[cabecote];
@@ -312,9 +312,9 @@ void print(int fin, FILE *arq)
         pont[5] = '\0';
         cont += 5;
 
-        // Adiciona cabecote na impress„o.
+        // Adiciona cabecote na impress√£o.
         strcat(fitaprint, pont);
-        // Adiciona a frente do cabecote na impress„o.
+        // Adiciona a frente do cabecote na impress√£o.
         for (int i = cabecote + 1; i < cabecote + (int)((LEN_FITA_PRINT) / 2) + 1; i++)
             fitaprint[cont++] = fita[i];
         fitaprint[LEN_FITA_PRINT + 6 - 1] = '\0';
@@ -328,9 +328,9 @@ void print(int fin, FILE *arq)
         {
             char op[3];
             long int n_temp = -1;
-            printf("\nForneÁa opÁ„o '-r', '-v', '-s numero' ou 'qualquer outro para continuar': ");
+            printf("\nForne√ßa op√ß√£o '-r', '-v', '-s numero' ou 'qualquer outro para continuar': ");
             return_scanf = scanf("%s", op);
-            // Pega a nova op de modo, se for -s ou -n trata possÌveis erros.
+            // Pega a nova op de modo, se for -s ou -n trata poss√≠veis erros.
             if (strlen(op) > 1)
                 switch (op[1])
                 {

--- a/exec.c
+++ b/exec.c
@@ -17,7 +17,7 @@ static size_t n_exec = 0;
 */
 void setseekbloco(FILE *arq, char *name_bloco)
 {
-    strcpy(bloco_atual, name_bloco);
+    memmove(bloco_atual, name_bloco, strlen(name_bloco) + 1);
     for (size_t i = 0; i < n_blocos; i++)
         if (strcmp(blocos[i].name, name_bloco) == 0)
         {

--- a/exec.h
+++ b/exec.h
@@ -10,23 +10,23 @@
 
 #define NO_LOOP 0          // 1-True, 0-False
 #define LIMIT_LOOP 1000000 // Max iteration for loop detection
-#define LEN_FITA_PRINT 40  // Tamanho da fita na impress„o
+#define LEN_FITA_PRINT 40  // Tamanho da fita na impress√£o
 
 typedef unsigned long long ullong;
 
 stack *pilha_blocos;          //  Pilha para chamada de blocos.
 char estado_atual[TAM_STATE]; //  Estado atual da maquina
 char novo_estado[TAM_STATE];  //  Estado atual e proximo a ser carrego.
-char bloco_atual[TAM_BLOCK];  //  Bloco atual de execuÁ„o da MT.
-char simbolo_atual[2];        //  Simbolo atual sobre o cabeÁote.
+char bloco_atual[TAM_BLOCK];  //  Bloco atual de execu√ß√£o da MT.
+char simbolo_atual[2];        //  Simbolo atual sobre o cabe√ßote.
 char fita[TAM_FITA];          //  Fita da MT.
-ullong cabecote;              //  PosiÁ„o do cabeÁote na fita da MT.
+ullong cabecote;              //  Posi√ß√£o do cabe√ßote na fita da MT.
 size_t seek;                  //  Semente para andar no arquivo.
 
-void execinstr(char **vetline, FILE *arq); // Executa instruÁ„o do tipo manipulador de sÌmbolos
-void execblock(char **vetline, FILE *arq); // Executa instruÁ„o do tipo chamada de blocos
+void execinstr(char **vetline, FILE *arq); // Executa instru√ß√£o do tipo manipulador de s√≠mbolos
+void execblock(char **vetline, FILE *arq); // Executa instru√ß√£o do tipo chamada de blocos
 void print(int fin, FILE *arq);            // Printa Status(FITA) na tela.
-void exec(FILE *arq);                      // Executa todo o algorÌtimo(arquivo) da MT.
+void exec(FILE *arq);                      // Executa todo o algor√≠timo(arquivo) da MT.
 void para(FILE *arq);                      // Finaliza a MT.
 
 #endif

--- a/main.c
+++ b/main.c
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 
 #ifdef _WIN32
     #define CLEAR "cls"
-#elif __linux__
+#elif __linux__ || (__APPLE__ && __MACH__)
     #define CLEAR "clear"
 #else
     #error "OS Not Supported"
@@ -36,9 +36,9 @@ void interface()
 {
     char input[TAM_INPUT];
     system(CLEAR);
-    printf("Simulador de Máquina de Turing ver. 1.1\nDesenvolvido como trabalho prático para ");
-    printf("a disciplina de Teoria da Computação\n");
-    printf("Autor: Júlio César M. Cândido - IFMG 2018 Campus Formiga.\n\nForneça a palavra inicial: ");
+    printf("Simulador de MÃ¡quina de Turing ver. 1.1\nDesenvolvido como trabalho prÃ¡tico para ");
+    printf("a disciplina de Teoria da ComputaÃ§Ã£o\n");
+    printf("Autor: JÃºlio CÃ©sar M. CÃ¢ndido - IFMG 2018 Campus Formiga.\n\nForneÃ§a a palavra inicial: ");
     scanf("%s", input);
     printf("\n");
     strncpy(fita, input, strlen(input));
@@ -47,11 +47,11 @@ void interface()
 void erroArgs(char *exec_name)
 {
     system(CLEAR);
-    printf("Error: Falta de parâmetro, exemplo:\n\n\t%s [Opções] [-head xx] <Fonte(MT)>\n\n", exec_name);
-    printf("Opções:\n\t< -r > Modo execução silenciosa (Padrão)\n\t");
+    printf("Error: Falta de parÃ¢metro, exemplo:\n\n\t%s [OpÃ§Ãµes] [-head xx] <Fonte(MT)>\n\n", exec_name);
+    printf("OpÃ§Ãµes:\n\t< -r > Modo execuÃ§Ã£o silenciosa (PadrÃ£o)\n\t");
     printf(" -v Modo debug, passo a passo\n\t");
-    printf(" -s n Executa n computações e espera uma novo modo de entrada\n\t");
-    printf(" -head xx Marcadores do cabeçote na impressão da fita\n\n");
-    printf(" Fonte(MT) Entrada com arquivo.MT com código de execução\n\n");
+    printf(" -s n Executa n computaÃ§Ãµes e espera uma novo modo de entrada\n\t");
+    printf(" -head xx Marcadores do cabeÃ§ote na impressÃ£o da fita\n\n");
+    printf(" Fonte(MT) Entrada com arquivo.MT com cÃ³digo de execuÃ§Ã£o\n\n");
     exit(1);
 }

--- a/main.c
+++ b/main.c
@@ -36,9 +36,9 @@ void interface()
 {
     char input[TAM_INPUT];
     system(CLEAR);
-    printf("Simulador de MÃ¡quina de Turing ver. 1.1\nDesenvolvido como trabalho prÃ¡tico para ");
-    printf("a disciplina de Teoria da ComputaÃ§Ã£o\n");
-    printf("Autor: JÃºlio CÃ©sar M. CÃ¢ndido - IFMG 2018 Campus Formiga.\n\nForneÃ§a a palavra inicial: ");
+    printf("Simulador de Máquina de Turing ver. 1.1\nDesenvolvido como trabalho prático para ");
+    printf("a disciplina de Teoria da Computação\n");
+    printf("Autor: Júlio César M. Cândido - IFMG 2018 Campus Formiga.\n\nForneça a palavra inicial: ");
     scanf("%s", input);
     printf("\n");
     strncpy(fita, input, strlen(input));
@@ -47,11 +47,11 @@ void interface()
 void erroArgs(char *exec_name)
 {
     system(CLEAR);
-    printf("Error: Falta de parÃ¢metro, exemplo:\n\n\t%s [OpÃ§Ãµes] [-head xx] <Fonte(MT)>\n\n", exec_name);
-    printf("OpÃ§Ãµes:\n\t< -r > Modo execuÃ§Ã£o silenciosa (PadrÃ£o)\n\t");
+    printf("Error: Falta de parâmetro, exemplo:\n\n\t%s [Opções] [-head xx] <Fonte(MT)>\n\n", exec_name);
+    printf("Opções:\n\t< -r > Modo execução silenciosa (Padrão)\n\t");
     printf(" -v Modo debug, passo a passo\n\t");
-    printf(" -s n Executa n computaÃ§Ãµes e espera uma novo modo de entrada\n\t");
-    printf(" -head xx Marcadores do cabeÃ§ote na impressÃ£o da fita\n\n");
-    printf(" Fonte(MT) Entrada com arquivo.MT com cÃ³digo de execuÃ§Ã£o\n\n");
+    printf(" -s n Executa n computações e espera uma novo modo de entrada\n\t");
+    printf(" -head xx Marcadores do cabeçote na impressão da fita\n\n");
+    printf(" Fonte(MT) Entrada com arquivo.MT com código de execução\n\n");
     exit(1);
 }

--- a/main.c
+++ b/main.c
@@ -36,9 +36,9 @@ void interface()
 {
     char input[TAM_INPUT];
     system(CLEAR);
-    printf("Simulador de Máquina de Turing ver. 1.1\nDesenvolvido como trabalho prático para ");
-    printf("a disciplina de Teoria da Computação\n");
-    printf("Autor: Júlio César M. Cândido - IFMG 2018 Campus Formiga.\n\nForneça a palavra inicial: ");
+    printf("Simulador de MÃ¡quina de Turing ver. 1.1\nDesenvolvido como trabalho prÃ¡tico para ");
+    printf("a disciplina de Teoria da ComputaÃ§Ã£o\n");
+    printf("Autor: JÃºlio CÃ©sar M. CÃ¢ndido - IFMG 2018 Campus Formiga.\n\nForneÃ§a a palavra inicial: ");
     scanf("%s", input);
     printf("\n");
     strncpy(fita, input, strlen(input));
@@ -47,11 +47,11 @@ void interface()
 void erroArgs(char *exec_name)
 {
     system(CLEAR);
-    printf("Error: Falta de parâmetro, exemplo:\n\n\t%s [Opções] [-head xx] <Fonte(MT)>\n\n", exec_name);
-    printf("Opções:\n\t< -r > Modo execução silenciosa (Padrão)\n\t");
+    printf("Error: Falta de parÃ¢metro, exemplo:\n\n\t%s [OpÃ§Ãµes] [-head xx] <Fonte(MT)>\n\n", exec_name);
+    printf("OpÃ§Ãµes:\n\t< -r > Modo execuÃ§Ã£o silenciosa (PadrÃ£o)\n\t");
     printf(" -v Modo debug, passo a passo\n\t");
-    printf(" -s n Executa n computações e espera uma novo modo de entrada\n\t");
-    printf(" -head xx Marcadores do cabeçote na impressão da fita\n\n");
-    printf(" Fonte(MT) Entrada com arquivo.MT com código de execução\n\n");
+    printf(" -s n Executa n computaÃ§Ãµes e espera uma novo modo de entrada\n\t");
+    printf(" -head xx Marcadores do cabeÃ§ote na impressÃ£o da fita\n\n");
+    printf(" Fonte(MT) Entrada com arquivo.MT com cÃ³digo de execuÃ§Ã£o\n\n");
     exit(1);
 }

--- a/main.c
+++ b/main.c
@@ -39,6 +39,7 @@ void interface()
     printf("Simulador de Máquina de Turing ver. 1.1\nDesenvolvido como trabalho prático para ");
     printf("a disciplina de Teoria da Computação\n");
     printf("Autor: Júlio César M. Cândido - IFMG 2018 Campus Formiga.\n\nForneça a palavra inicial: ");
+    fflush(stdout);
     scanf("%s", input);
     printf("\n");
     strncpy(fita, input, strlen(input));

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-MYFLAGS = -g -O2 -Wall
+MYFLAGS = -g -O2 -Wall -fcommon
 
 TARGET = simturing
 

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-MYFLAGS = -g -O2 -Wall -fcommon
+MYFLAGS = -g -O2 -Wall -fcommon -fsanitize=address
 
 TARGET = simturing
 
@@ -13,7 +13,7 @@ all:
 
 # regras para gerar o executavel
 $(TARGET): $(OBJFILES) 
-	$(CC) -o $(TARGET) $(OBJFILES) 
+	$(CC) $(MYFLAGS) -o $(TARGET) $(OBJFILES) 
 
 # regras de compilação
 decodArgs.o: decodArgs.c decodArgs.h

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-MYFLAGS = -g -O2 -Wall -fcommon -fsanitize=address
+MYFLAGS = -g -O2 -Wall -fcommon
 
 TARGET = simturing
 
@@ -13,7 +13,7 @@ all:
 
 # regras para gerar o executavel
 $(TARGET): $(OBJFILES) 
-	$(CC) $(MYFLAGS) -o $(TARGET) $(OBJFILES) 
+	$(CC) -o $(TARGET) $(OBJFILES) 
 
 # regras de compilação
 decodArgs.o: decodArgs.c decodArgs.h

--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ stack.o: stack.c stack.h decodc.h
 
 clean:
 	rm -f *.o
-	rm $(TARGET)
+	rm -f $(TARGET)
 
 clear:
 	rm -f *.o

--- a/palindrome.mt
+++ b/palindrome.mt
@@ -1,6 +1,6 @@
 ;
-;	Verifica se a sequencia de 0 e 1, È uma palindrome
-;	 respondendo sim ou n„o.
+;	Verifica se a sequencia de 0 e 1, √© uma palindrome
+;	 respondendo sim ou n√£o.
 ;
 bloco main 01
 

--- a/soma.mt
+++ b/soma.mt
@@ -1,6 +1,6 @@
 ;
 ;
-;   Efetua a soma de dois números binários de mesmo tamanho
+;   Efetua a soma de dois nÃºmeros binÃ¡rios de mesmo tamanho
 ;   ambos separados por '#'
 ;
 ;   Exemplo: 010#101

--- a/stack.h
+++ b/stack.h
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include "decodc.h"
 
-typedef struct cell cell;     //  Célula com dados e ponteiro da pilha.
+typedef struct cell cell;     //  CÃ©lula com dados e ponteiro da pilha.
 typedef struct recall recall; //  Estrutura com dados dos blocos.
 typedef struct stack stack;   //  Ponteiro topo da pilha.
 
@@ -19,7 +19,7 @@ struct cell // Estrutura a ser empilhada na pilha.
     cell *bot;
 };
 
-struct recall // Estrutura dos dados alocados na célula.
+struct recall // Estrutura dos dados alocados na cÃ©lula.
 {
     char recall_bloco[TAM_BLOCK]; // Nome do bloco.
     char recall_state[TAM_STATE];


### PR DESCRIPTION
## Changes
- Adapted the clear screen macro for macOS compatibility
- Converted charset from ISO-8859-1 to UTF-8
- Resolved **strcpy-param-overlap** issue at exec.c:20
- Added the **-fcommon** flag to handle extern global variables
- fflush(stdout) before scanf

## Tested on MacOS arm64 / Linux Arm64
![turing-machine-mac-build](https://github.com/user-attachments/assets/b4bc7c75-c045-40a6-99ad-e384ae2c7d69)
